### PR TITLE
Update 11ty and sub-packages to latest stable versions

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,4 @@
-const pluginRss = require("@11ty/eleventy-plugin-rss");
+const { default: pluginRss } = require("@11ty/eleventy-plugin-rss");
 const { DateTime } = require("luxon");
 const SaxonJS = require("saxon-js");
 const toml = require("@iarna/toml");

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
         "": {
             "name": "benadme-11ty-test",
             "devDependencies": {
-                "@11ty/eleventy": "^3.1.2",
-                "@11ty/eleventy-navigation": "^1.0.4",
-                "@11ty/eleventy-plugin-bundle": "^3.0.6",
-                "@11ty/eleventy-plugin-rss": "^2.0.4",
-                "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
+                "@11ty/eleventy": "^3.1.5",
+                "@11ty/eleventy-navigation": "^1.0.5",
+                "@11ty/eleventy-plugin-bundle": "^3.0.7",
+                "@11ty/eleventy-plugin-rss": "^3.0.0",
+                "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
                 "@iarna/toml": "^2.2.5",
                 "adm-zip": "^0.5.16",
                 "luxon": "^3.7.1",
@@ -23,9 +23,9 @@
             }
         },
         "node_modules/@11ty/dependency-tree": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.0.tgz",
-            "integrity": "sha512-PTOnwM8Xt+GdJmwRKg4pZ8EKAgGoK7pedZBfNSOChXu8MYk2FdEsxdJYecX4t62owpGw3xK60q9TQv/5JI59jw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.2.tgz",
+            "integrity": "sha512-RTF6VTZHatYf7fSZBUN3RKwiUeJh5dhWV61gDPrHhQF2/gzruAkYz8yXuvGLx3w3ZBKreGrR+MfYpSVkdbdbLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -33,58 +33,58 @@
             }
         },
         "node_modules/@11ty/dependency-tree-esm": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree-esm/-/dependency-tree-esm-2.0.0.tgz",
-            "integrity": "sha512-+4ySOON4aEAiyAGuH6XQJtxpGSpo6nibfG01krgix00sqjhman2+UaDUopq6Ksv8/jBB3hqkhsHe3fDE4z8rbA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree-esm/-/dependency-tree-esm-2.0.4.tgz",
+            "integrity": "sha512-MYKC0Ac77ILr1HnRJalzKDlb9Z8To3kXQCltx299pUXXUFtJ1RIONtULlknknqW8cLe19DLVgmxVCtjEFm7h0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@11ty/eleventy-utils": "^2.0.1",
-                "acorn": "^8.14.0",
+                "@11ty/eleventy-utils": "^2.0.7",
+                "acorn": "^8.15.0",
                 "dependency-graph": "^1.0.0",
                 "normalize-path": "^3.0.0"
             }
         },
         "node_modules/@11ty/eleventy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.2.tgz",
-            "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.5.tgz",
+            "integrity": "sha512-hZ0g6MwZyRxCqXsPm82gIM304LraKbUz3ZmezOSjsqxttZG6cHTib3Qq8QkESJoKwnr+yX1eyfOkPC5/mEgZnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@11ty/dependency-tree": "^4.0.0",
-                "@11ty/dependency-tree-esm": "^2.0.0",
+                "@11ty/dependency-tree": "^4.0.2",
+                "@11ty/dependency-tree-esm": "^2.0.4",
                 "@11ty/eleventy-dev-server": "^2.0.8",
-                "@11ty/eleventy-plugin-bundle": "^3.0.6",
+                "@11ty/eleventy-plugin-bundle": "^3.0.7",
                 "@11ty/eleventy-utils": "^2.0.7",
                 "@11ty/lodash-custom": "^4.17.21",
-                "@11ty/posthtml-urls": "^1.0.1",
-                "@11ty/recursive-copy": "^4.0.2",
+                "@11ty/posthtml-urls": "^1.0.2",
+                "@11ty/recursive-copy": "^4.0.4",
                 "@sindresorhus/slugify": "^2.2.1",
                 "bcp-47-normalize": "^2.3.0",
                 "chokidar": "^3.6.0",
-                "debug": "^4.4.1",
+                "debug": "^4.4.3",
                 "dependency-graph": "^1.0.0",
                 "entities": "^6.0.1",
                 "filesize": "^10.1.6",
                 "gray-matter": "^4.0.3",
                 "iso-639-1": "^3.1.5",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.1.1",
                 "kleur": "^4.1.5",
-                "liquidjs": "^10.21.1",
-                "luxon": "^3.6.1",
-                "markdown-it": "^14.1.0",
+                "liquidjs": "^10.25.0",
+                "luxon": "^3.7.2",
+                "markdown-it": "^14.1.1",
                 "minimist": "^1.2.8",
-                "moo": "^0.5.2",
+                "moo": "0.5.2",
                 "node-retrieve-globals": "^6.0.1",
                 "nunjucks": "^3.2.4",
-                "picomatch": "^4.0.2",
+                "picomatch": "^4.0.3",
                 "please-upgrade-node": "^3.2.0",
-                "posthtml": "^0.16.6",
+                "posthtml": "^0.16.7",
                 "posthtml-match-helper": "^2.0.3",
-                "semver": "^7.7.2",
-                "slugify": "^1.6.6",
-                "tinyglobby": "^0.2.14"
+                "semver": "^7.7.4",
+                "slugify": "^1.6.8",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "eleventy": "cmd.cjs"
@@ -129,9 +129,9 @@
             }
         },
         "node_modules/@11ty/eleventy-navigation": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-1.0.4.tgz",
-            "integrity": "sha512-FgIfKiFP1e3plQdIvSRph1tFV44bbCXcYs+AWcwnsfrn5I6Gf0t3hBq9IrR4JdnZ06hlEKq8qRbnbb0nfEZg3A==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-1.0.5.tgz",
+            "integrity": "sha512-zb6xe29cM9viSdYtZywKIkJw2HIROyBINdBcFWC9uD0c/jYOTAex5nwy3HNEuh5t6/Ld/S9V4gEizfmeYuYpCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -143,9 +143,9 @@
             }
         },
         "node_modules/@11ty/eleventy-plugin-bundle": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-bundle/-/eleventy-plugin-bundle-3.0.6.tgz",
-            "integrity": "sha512-wlEIMa1SEe6HE6ZyREEnPQiTw72337a2MPkyn0D1IzrqHrKU9euB17mv27LnnnyKvMJamCCqtU0985F5yyDL8g==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-bundle/-/eleventy-plugin-bundle-3.0.7.tgz",
+            "integrity": "sha512-QK1tRFBhQdZASnYU8GMzpTdsMMFLVAkuU0gVVILqNyp09xJJZb81kAS3AFrNrwBCsgLxTdWHJ8N64+OTTsoKkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -162,16 +162,16 @@
             }
         },
         "node_modules/@11ty/eleventy-plugin-rss": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-2.0.4.tgz",
-            "integrity": "sha512-LF60sGVlxGTryQe3hTifuzrwF8R7XbrNsM2xfcDcNMSliLN4kmB+7zvoLRySRx0AQDjqhPTAeeeT0ra6/9zHUQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-3.0.0.tgz",
+            "integrity": "sha512-kKW4DcR57xAyRx0e8gNhKh56ahHVEaAj8/TuXQDnw+B46ig2bWADJAlyj/GdV37IG5ja9dZ4SgKZrs/CHz6YWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@11ty/eleventy-utils": "^2.0.0",
-                "@11ty/posthtml-urls": "^1.0.1",
-                "debug": "^4.4.0",
-                "posthtml": "^0.16.6"
+                "@11ty/eleventy-utils": "^2.0.7",
+                "@11ty/posthtml-urls": "^1.0.2",
+                "debug": "^4.4.3",
+                "posthtml": "^0.16.7"
             },
             "funding": {
                 "type": "opencollective",
@@ -179,9 +179,9 @@
             }
         },
         "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.1.tgz",
-            "integrity": "sha512-xDPF3Ay38XlmWZe9ER0SLtMmNah7olUBlGORhUiCUkPh3jYGVCDTDayi4tbFI9Dxha8NwKlfBZ2FXM/s3aZzAg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
+            "integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -227,9 +227,9 @@
             }
         },
         "node_modules/@11ty/eleventy/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -253,9 +253,9 @@
             }
         },
         "node_modules/@11ty/posthtml-urls": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@11ty/posthtml-urls/-/posthtml-urls-1.0.1.tgz",
-            "integrity": "sha512-6EFN/yYSxC/OzYXpq4gXDyDMlX/W+2MgCvvoxf11X1z76bqkqFJ8eep5RiBWfGT5j0323a1pwpelcJJdR46MCw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@11ty/posthtml-urls/-/posthtml-urls-1.0.3.tgz",
+            "integrity": "sha512-1YvhnkaNlFnnJic1rBMWmTC2adbuy+JQiBfl1Hecr1Wjjik1pQZmGyk/eC9zKX/FQv52s2Nht1Gi/UwhYqrBeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -268,26 +268,16 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/@11ty/posthtml-urls/node_modules/http-equiv-refresh": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-2.0.1.tgz",
-            "integrity": "sha512-XJpDL/MLkV3dKwLzHwr2dY05dYNfBNlyPu4STQ8WvKCFdc6vC5tPXuq28of663+gHVg03C+16pHHs/+FmmDjcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@11ty/recursive-copy": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.3.tgz",
-            "integrity": "sha512-SX48BTLEGX8T/OsKWORsHAAeiDsbFl79Oa/0Wg/mv/d27b7trCVZs7fMHvpSgDvZz/fZqx5rDk8+nx5oyT7xBw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.4.tgz",
+            "integrity": "sha512-oI7m8pa7/IAU/3lqRU9vjBbs20iKFo7x+1K9kT3aVira6scc1X9MjBdgLCHzLJeJ7iB6wydioA+kr9/qPnvmlQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "errno": "^1.0.0",
                 "junk": "^3.1.0",
-                "maximatch": "^0.1.0",
+                "minimatch": "^3.1.5",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -422,49 +412,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-uniq": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -549,9 +496,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -641,9 +588,9 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -693,6 +640,7 @@
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
             "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -707,6 +655,7 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -721,13 +670,15 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/fb55"
                 }
-            ]
+            ],
+            "license": "BSD-2-Clause"
         },
         "node_modules/domhandler": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -743,6 +694,7 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -1197,6 +1149,7 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.2",
@@ -1209,11 +1162,22 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
             "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/http-equiv-refresh": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-2.0.1.tgz",
+            "integrity": "sha512-XJpDL/MLkV3dKwLzHwr2dY05dYNfBNlyPu4STQ8WvKCFdc6vC5tPXuq28of663+gHVg03C+16pHHs/+FmmDjcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/http-errors": {
@@ -1323,7 +1287,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
             "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -1421,12 +1386,13 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
             "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/luxon": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
-            "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1489,22 +1455,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/maximatch": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
-            "integrity": "sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/mdurl": {
@@ -1675,7 +1625,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
             "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -1688,10 +1639,11 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -1710,10 +1662,11 @@
             }
         },
         "node_modules/posthtml": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
-            "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
+            "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "posthtml-parser": "^0.11.0",
                 "posthtml-render": "^3.0.0"
@@ -1740,6 +1693,7 @@
             "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
             "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "htmlparser2": "^7.1.1"
             },
@@ -1752,6 +1706,7 @@
             "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
             "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-json": "^2.0.1"
             },
@@ -1838,9 +1793,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1921,10 +1876,11 @@
             }
         },
         "node_modules/slugify": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -1968,14 +1924,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1985,11 +1941,14 @@
             }
         },
         "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -2000,9 +1959,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "xslt3": "^2.7.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19"
             }
         },
         "node_modules/@11ty/dependency-tree": {
@@ -1362,9 +1362,9 @@
             }
         },
         "node_modules/liquidjs": {
-            "version": "10.25.0",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.0.tgz",
-            "integrity": "sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==",
+            "version": "10.25.5",
+            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.5.tgz",
+            "integrity": "sha512-GKiKeZjJDdVoQAu+S9rzkYsYnYhcep5W3WwZXgb5f+yq484P/k9JqamBbGYu+LBEixcUAXZr2jogdAIjB3ki1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
         "prebuild": "npx xslt3 -xsl:src/page.xsl -s:src/page.xsl -export:_generated/page.sef.json -t"
     },
     "engines": {
-        "node": ">=18"
+        "node": ">=20.19"
     },
     "devDependencies": {
-        "@11ty/eleventy": "^3.1.2",
-        "@11ty/eleventy-navigation": "^1.0.4",
-        "@11ty/eleventy-plugin-bundle": "^3.0.6",
-        "@11ty/eleventy-plugin-rss": "^2.0.4",
-        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.1",
+        "@11ty/eleventy": "^3.1.5",
+        "@11ty/eleventy-navigation": "^1.0.5",
+        "@11ty/eleventy-plugin-bundle": "^3.0.7",
+        "@11ty/eleventy-plugin-rss": "^3.0.0",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "@iarna/toml": "^2.2.5",
         "adm-zip": "^0.5.16",
         "luxon": "^3.7.1",


### PR DESCRIPTION
## Summary

Updates all `@11ty` packages to their latest stable versions and applies security fixes.

### Package updates

| Package | Previous | Updated |
|---|---|---|
| `@11ty/eleventy` | ^3.1.2 | ^3.1.5 |
| `@11ty/eleventy-navigation` | ^1.0.4 | ^1.0.5 |
| `@11ty/eleventy-plugin-bundle` | ^3.0.6 | ^3.0.7 |
| `@11ty/eleventy-plugin-rss` | ^2.0.4 | ^3.0.0 |
| `@11ty/eleventy-plugin-syntaxhighlight` | ^5.0.1 | ^5.0.2 |

### Other changes

- `engines.node` bumped to `>=20.19` to reflect the RSS plugin v3 requirement for `require()` support of ESM packages
- Fixed `eleventy.config.js` to use `const { default: pluginRss } = require(...)` for the ESM-only RSS plugin v3
- Applied `npm audit fix` - resolved 1 high severity vulnerability (0 remaining)

### Output verification

The generated `_site/` output is identical to the `main` branch build, with the sole exception of `lastBuildDate` in `blog/index.xml` (which reflects the build timestamp).

---

> This PR and its commits were created by Claude Sonnet 4.6 via GitHub Copilot.