### PR TITLE
Update Eleventy to 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "benadme-11ty-test",
             "devDependencies": {
-                "@11ty/eleventy": "^3.1.5",
+                "@11ty/eleventy": "^3.1.6",
                 "@11ty/eleventy-navigation": "^1.0.5",
                 "@11ty/eleventy-plugin-bundle": "^3.0.7",
                 "@11ty/eleventy-plugin-rss": "^3.0.0",
@@ -46,9 +46,9 @@
             }
         },
         "node_modules/@11ty/eleventy": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.5.tgz",
-            "integrity": "sha512-hZ0g6MwZyRxCqXsPm82gIM304LraKbUz3ZmezOSjsqxttZG6cHTib3Qq8QkESJoKwnr+yX1eyfOkPC5/mEgZnQ==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.6.tgz",
+            "integrity": "sha512-ZlSiR1PLdS2lv7TelBgWAhcvMiLNZkPBlLEb+lh7kGYZ+Mk0bo9qcYgVsewvw9W7Em0RH3wd01h5fAstNDh0zA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -58,7 +58,7 @@
                 "@11ty/eleventy-plugin-bundle": "^3.0.7",
                 "@11ty/eleventy-utils": "^2.0.7",
                 "@11ty/lodash-custom": "^4.17.21",
-                "@11ty/posthtml-urls": "^1.0.2",
+                "@11ty/posthtml-urls": "^1.0.3",
                 "@11ty/recursive-copy": "^4.0.4",
                 "@sindresorhus/slugify": "^2.2.1",
                 "bcp-47-normalize": "^2.3.0",
@@ -71,20 +71,20 @@
                 "iso-639-1": "^3.1.5",
                 "js-yaml": "^4.1.1",
                 "kleur": "^4.1.5",
-                "liquidjs": "^10.25.0",
+                "liquidjs": "^10.27.0",
                 "luxon": "^3.7.2",
-                "markdown-it": "^14.1.1",
+                "markdown-it": "^14.2.0",
                 "minimist": "^1.2.8",
                 "moo": "0.5.2",
                 "node-retrieve-globals": "^6.0.1",
                 "nunjucks": "^3.2.4",
-                "picomatch": "^4.0.3",
+                "picomatch": "^4.0.4",
                 "please-upgrade-node": "^3.2.0",
                 "posthtml": "^0.16.7",
                 "posthtml-match-helper": "^2.0.3",
-                "semver": "^7.7.4",
-                "slugify": "^1.6.8",
-                "tinyglobby": "^0.2.15"
+                "semver": "^7.8.1",
+                "slugify": "^1.6.9",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "eleventy": "cmd.cjs"
@@ -1380,10 +1380,20 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -1428,15 +1438,25 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -1825,9 +1845,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1956,14 +1976,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "node": ">=20.19"
     },
     "devDependencies": {
-        "@11ty/eleventy": "^3.1.5",
+        "@11ty/eleventy": "^3.1.6",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-bundle": "^3.0.7",
         "@11ty/eleventy-plugin-rss": "^3.0.0",


### PR DESCRIPTION
Bumps `@11ty/eleventy` from 3.1.5 to 3.1.6 (current `latest` patch release; mostly dependency/security fixes).

## Verification
Built the site with both versions and recursively diffed `_site/`:
- 621 files written by each build; all rendered HTML/assets are byte-identical.
- The only content difference is the RSS feed's `<lastBuildDate>` timestamp in `blog/index.xml`, which changes on every build by design.

Only `package.json` and `package-lock.json` change (`_generated/` and `_site/` are git-ignored).