### PR TITLE
Add byte-identical site verification skill

### DIFF
--- a/.github/skills/verify-byte-identical-site.md
+++ b/.github/skills/verify-byte-identical-site.md
@@ -1,0 +1,29 @@
+---
+name: Verify Generated Site Is Byte-Identical
+description: Build a baseline, rebuild after a change, and diff _site/ to prove the generated site did not change.
+---
+
+# Verify Generated Site Is Byte-Identical
+
+Use this skill when you need to prove a site change preserved the generated output.
+
+## Workflow
+
+1. Run `npm ci`, `npm run prebuild`, and `npm run build`.
+2. Copy `_site/` to a snapshot outside the repo.
+3. Make the change.
+4. Re-run `npm run prebuild` if XSL changed, then `npm run build`.
+5. Diff the new `_site/` against the snapshot.
+6. Treat the RSS `<lastBuildDate>` change in `content/blogrss.njk` as expected build noise.
+
+## Rules
+
+- Use the repo's documented build commands.
+- Keep `_generated/` and `_site/` out of git.
+- If the diff is not just expected timestamp noise, investigate the rendering change before shipping.
+
+## Useful when
+
+- Verifying Eleventy upgrades.
+- Checking template edits for accidental output changes.
+- Proving a refactor is behavior-preserving.

--- a/.github/skills/verify-byte-identical-site.md
+++ b/.github/skills/verify-byte-identical-site.md
@@ -18,7 +18,7 @@ Use this skill when you need to prove a site change preserved the generated outp
 
 ## Rules
 
-- Use `npm run build`; it refreshes the XSL output first.
+- Use `npm run build`.
 - Keep `_generated/` and `_site/` out of git.
 - If the diff is not just expected timestamp noise, investigate the rendering change before shipping.
 

--- a/.github/skills/verify-byte-identical-site.md
+++ b/.github/skills/verify-byte-identical-site.md
@@ -9,16 +9,16 @@ Use this skill when you need to prove a site change preserved the generated outp
 
 ## Workflow
 
-1. Run `npm ci`, `npm run prebuild`, and `npm run build`.
+1. Run `npm ci` and `npm run build`.
 2. Copy `_site/` to a snapshot outside the repo.
 3. Make the change.
-4. Re-run `npm run prebuild` if XSL changed, then `npm run build`.
+4. Re-run `npm run build` after the change.
 5. Diff the new `_site/` against the snapshot.
 6. Treat the RSS `<lastBuildDate>` change in `content/blogrss.njk` as expected build noise.
 
 ## Rules
 
-- Use the repo's documented build commands.
+- Use `npm run build`; it refreshes the XSL output first.
 - Keep `_generated/` and `_site/` out of git.
 - If the diff is not just expected timestamp noise, investigate the rendering change before shipping.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "benadme-11ty-test",
     "scripts": {
-        "build": "npm run prebuild && npx @11ty/eleventy",
+        "build": "npx @11ty/eleventy",
         "start": "npx @11ty/eleventy --serve --quiet",
         "debug": "DEBUG=Eleventy* npx @11ty/eleventy",
         "debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "benadme-11ty-test",
     "scripts": {
-        "build": "npx @11ty/eleventy",
+        "build": "npm run prebuild && npx @11ty/eleventy",
         "start": "npx @11ty/eleventy --serve --quiet",
         "debug": "DEBUG=Eleventy* npx @11ty/eleventy",
         "debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",


### PR DESCRIPTION
Adds a repo-local skill for the recurring generated-site verification workflow: baseline build, snapshot _site/, rebuild, diff, and account for the expected RSS <lastBuildDate> noise.

The skill is intentionally narrow and focused on output verification only.